### PR TITLE
Use HEAD request for checking streaming support

### DIFF
--- a/src/display/fetch_stream.js
+++ b/src/display/fetch_stream.js
@@ -29,9 +29,9 @@ if (typeof PDFJSDev !== "undefined" && PDFJSDev.test("MOZCENTRAL")) {
   );
 }
 
-function createFetchOptions(headers, withCredentials, abortController) {
+function createFetchOptions(method, headers, withCredentials, abortController) {
   return {
-    method: "GET",
+    method,
     headers,
     signal: abortController.signal,
     mode: "cors",
@@ -121,7 +121,12 @@ class PDFFetchStreamReader {
     const url = source.url;
     fetch(
       url,
-      createFetchOptions(headers, this._withCredentials, this._abortController)
+      createFetchOptions(
+        "HEAD",
+        headers,
+        this._withCredentials,
+        this._abortController
+      )
     )
       .then(response => {
         stream._responseOrigin = getResponseOrigin(response.url);
@@ -219,7 +224,12 @@ class PDFFetchStreamRangeReader {
     const url = source.url;
     fetch(
       url,
-      createFetchOptions(headers, this._withCredentials, this._abortController)
+      createFetchOptions(
+        "GET",
+        headers,
+        this._withCredentials,
+        this._abortController
+      )
     )
       .then(response => {
         const responseOrigin = getResponseOrigin(response.url);


### PR DESCRIPTION
PDF.js is primarily a library for viewing PDFs on the Web.

However, thanks to the excellent work done over the years, the library is also a useful tool for working with PDF files in general.
This PR aims to improve PDF file downloading even in environments or applications where PDF.js is used as a rendering engine without using the Mozilla viewer.

For more information: https://github.com/mozilla/pdf.js/issues/11669